### PR TITLE
Fix deque pop logic and free memory

### DIFF
--- a/main-multi.c
+++ b/main-multi.c
@@ -293,16 +293,26 @@ Location _front(Deque* _d) { return _d->head->data; }
 Location _back(Deque* _d) { return _d->tail->data; }
 void _pop_front(Deque* _d) {
     if (_d->size <= 0) return;
-    Node* newHead = _d->head->next;
-    free(_d->head);
+    Node* oldHead = _d->head;
+    Node* newHead = oldHead->next;
+    free(oldHead);
     _d->head = newHead;
+    if (newHead)
+        newHead->prev = NULL;
+    else
+        _d->tail = NULL;
     _d->size--;
 }
 void _pop_back(Deque* _d) {
     if (_d->size <= 0) return;
-    Node* newTail = _d->tail->prev;
-    free(_d->tail);
+    Node* oldTail = _d->tail;
+    Node* newTail = oldTail->prev;
+    free(oldTail);
     _d->tail = newTail;
+    if (newTail)
+        newTail->next = NULL;
+    else
+        _d->head = NULL;
     _d->size--;
 }
 Deque* newDeque() {
@@ -402,16 +412,26 @@ char* _2front(StrDeque* _d) { return _d->head->data; }
 char* _2back(StrDeque* _d) { return _d->tail->data; }
 void _2pop_front(StrDeque* _d) {
     if (_d->size <= 0) return;
-    StrNode* newHead = _d->head->next;
-    free(_d->head);
+    StrNode* oldHead = _d->head;
+    StrNode* newHead = oldHead->next;
+    free(oldHead);
     _d->head = newHead;
+    if (newHead)
+        newHead->prev = NULL;
+    else
+        _d->tail = NULL;
     _d->size--;
 }
-void _2pop_back(Deque* _d) {
+void _2pop_back(StrDeque* _d) {
     if (_d->size <= 0) return;
-    Node* newTail = _d->tail->prev;
-    free(_d->tail);
+    StrNode* oldTail = _d->tail;
+    StrNode* newTail = oldTail->prev;
+    free(oldTail);
     _d->tail = newTail;
+    if (newTail)
+        newTail->next = NULL;
+    else
+        _d->head = NULL;
     _d->size--;
 }
 StrDeque* newStrDeque() {
@@ -561,7 +581,9 @@ void _generateApple(Snake* S) {
 
 Snake* newSnake() {
     Snake* newS = (Snake*)malloc(sizeof(Snake));
-    newS->block = *(newDeque());
+    Deque* tmp = newDeque();
+    newS->block = *tmp;
+    free(tmp);
     Deque* block = &(newS->block);
     newS->isGameOvered = false;
     newS->score = 0;

--- a/main-single.c
+++ b/main-single.c
@@ -206,16 +206,26 @@ Location _front(Deque* _d) { return _d->head->data; }
 Location _back(Deque* _d) { return _d->tail->data; }
 void _pop_front(Deque* _d) {
     if (_d->size <= 0) return;
-    Node* newHead = _d->head->next;
-    free(_d->head);
+    Node* oldHead = _d->head;
+    Node* newHead = oldHead->next;
+    free(oldHead);
     _d->head = newHead;
+    if (newHead)
+        newHead->prev = NULL;
+    else
+        _d->tail = NULL;
     _d->size--;
 }
 void _pop_back(Deque* _d) {
     if (_d->size <= 0) return;
-    Node* newTail = _d->tail->prev;
-    free(_d->tail);
+    Node* oldTail = _d->tail;
+    Node* newTail = oldTail->prev;
+    free(oldTail);
     _d->tail = newTail;
+    if (newTail)
+        newTail->next = NULL;
+    else
+        _d->head = NULL;
     _d->size--;
 }
 Deque* newDeque() {
@@ -362,7 +372,9 @@ void _generateApple(Snake* S) {
 
 Snake* newSnake() {
     Snake* newS = (Snake*)malloc(sizeof(Snake));
-    newS->block = *(newDeque());
+    Deque* tmp = newDeque();
+    newS->block = *tmp;
+    free(tmp);
     Deque* block = &(newS->block);
     newS->isGameOvered = false;
     newS->score = 0;


### PR DESCRIPTION
## Summary
- fix missing head/tail updates in `_pop_front` and `_pop_back`
- correct string deque pop functions
- avoid memory leak when initializing snake deque

## Testing
- `gcc -c main-single.c -o /tmp/single.o` *(fails: `windows.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a63982c9c8331ad9fe5b9c7e2c8d7